### PR TITLE
Optimize the `compile()` and `show()` method for TikzPicture

### DIFF
--- a/src/tikzpy/tikz_environments/tikz_picture.py
+++ b/src/tikzpy/tikz_environments/tikz_picture.py
@@ -139,7 +139,7 @@ class TikzPicture(TikzEnvironment):
         self, pdf_destination: Optional[str] = None, quiet: bool = True
     ) -> Path:
         """Compiles the Tikz code and returns a Path to the final PDF.
-        If no file path is provided, a default value of ".temp/TEMP_DIR/temp.pdf" will be used.
+        If no file path is provided, a default value of "{self.TEMP_DIR}/temp.pdf" will be used.
 
         Parameters:
             pdf_destination (str): The file path of the compiled pdf.


### PR DESCRIPTION
- Set temp dir to `Path.cwd()/.tikz_temp<id: TikzPicture>`
- Don't clean temp dir in `TikzPicture.compile()`
- Add `TikzPicture.close()` for cleaning temp dir
- `shutil.copy()` is better than `Path.replace` in copying pdf file to destination (Please refer to [this link](https://www.reddit.com/r/learnpython/comments/u21s2q/does_pathreplace_perform_a_move_or_copy/))
- Add jupyter notebook support in `TikzPicture.show()`